### PR TITLE
Fix github actions (#2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ build/*
 install/*
 log/*
 site/*
+# Packages should be their own git repositories and not added to the ros2 devcontainer
+# Use ROS tools like vcstool to setup your workspace
+src/**/

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,3 +1,0 @@
-# Packages should be their own git repositories and not added to the ros2 devcontainer
-# Use ROS tools like vcstool to setup your workspace
-*

--- a/src/ros2.repos
+++ b/src/ros2.repos
@@ -1,0 +1,8 @@
+############
+# Example:
+############
+repositories:
+  examples:
+    type: git
+    url: https://github.com/ros2/examples.git
+    version: humble


### PR DESCRIPTION
* restore the example ros2.repos for CI

* .gitignore only excludes subdirectories of src but allows files like ros2.repos